### PR TITLE
Fix inline css

### DIFF
--- a/packages/serlina/lib/components/Document.tsx
+++ b/packages/serlina/lib/components/Document.tsx
@@ -39,7 +39,7 @@ export default ({
         {helmet.style.toComponent()}
         {helmet.link.toComponent()}
         {inlineCSSString ? inlineCSSString.map(str => {
-          return <style key={str.slice(0, 8)}>{inlineCSSString}</style>
+          return <style key={str.slice(0, 8)} dangerouslySetInnerHTML={{__html: str}}></style>
         }) : pageStyles.map(url => {
           return <link key={url} rel='stylesheet' href={publicPath + url} />
         })}

--- a/packages/serlina/lib/serlina.ts
+++ b/packages/serlina/lib/serlina.ts
@@ -82,7 +82,7 @@ class Serlina {
   }
 
   constructor(options: SerlinaOptions) {
-    const {
+    let {
       baseDir = '',
       host = DEV_SERVER_HOST,
       port = DEV_SERVER_PORT,
@@ -91,12 +91,16 @@ class Serlina {
       outputPath = path.resolve(baseDir, '.serlina'),
       dev = true,
       // @ts-ignore
-      publicPath = dev ? 'http://' + host + ':' + port + '/' : '/',
+      publicPath = '/',
       forceBuild = false,
       __serlinaConfig,
       __testing,
       inlineCSS
     } = options
+    
+    if (dev) {
+      publicPath = 'http://' + host + ':' + port + '/'
+    }
 
     const serlinaConfig = __serlinaConfig ? __serlinaConfig : (fs.existsSync(path.resolve(baseDir, './serlina.config.js')) ? require(path.resolve(baseDir, './serlina.config.js')) : {})
 


### PR DESCRIPTION
Resolved two problems from 1daf7428cc0d7e146ec07d1b921c05c149713a44

1. Use dangerouslySetInnerHTML in style, otherwise React will escape them.
2. Don't set publicPath in default value. It might break [this rule](https://serlina.js.org/#/api?id=publicpath).

> It works only when dev mode is false.