### PR TITLE
[fix]WDS options set sockPort to the option.port

### DIFF
--- a/packages/serlina/lib/serlina.ts
+++ b/packages/serlina/lib/serlina.ts
@@ -170,6 +170,7 @@ class Serlina {
     if (this.options.dev === true && this.options.__testing !== true) {
       const devServerOptions = {
         quiet: true,
+        sockPort: this.options.port,
         // inline: true,
         // hot: true,
         // port: this.options.port,


### PR DESCRIPTION
currently, webpack dev server sock port is default set to the url port.However,it should be same to dev server port.